### PR TITLE
Fix docstring typos

### DIFF
--- a/src/Class_Function.py
+++ b/src/Class_Function.py
@@ -258,8 +258,8 @@ class Disclosure_10K():
       #self.corrupted = True
 
   def Remove_Tables_hreflinks(self):
-    '''This function Removes a table, if it contains an href link which means this is the table of contents!
-    As a side bonous, it also removes the phrase table of contents whithin the text (At the end of each page, there is sometimes links to the table of contents'''
+    '''This function removes a table if it contains an href link, which indicates it is the table of contents.
+    As a side bonus, it also removes the phrase "table of contents" within the text (at the end of each page there is sometimes a link to the table of contents).'''
 
     regex = '\s*table\s*of\s*contents'
     for element in self.soup.find_all('a', string=re.compile(regex, re.IGNORECASE)):
@@ -812,8 +812,8 @@ class Disclosure():
 
 
   def Remove_Tables_hreflinks(self):
-    '''This function Removes a table, if it contains an href link which means this is the table of contents!
-    As a side bonous, it also removes the phrase table of contents whithin the text (At the end of each page, there is sometimes links to the table of contents'''
+    '''This function removes a table if it contains an href link, which indicates it is the table of contents.
+    As a side bonus, it also removes the phrase "table of contents" within the text (at the end of each page there is sometimes a link to the table of contents).'''
 
     regex = '\s*table\s*of\s*contents'
     for element in self.soup.find_all('a', string=re.compile(regex, re.IGNORECASE)):

--- a/src/classes2.py
+++ b/src/classes2.py
@@ -219,8 +219,8 @@ class Disclosure_10K():
       #self.corrupted = True
 
   def Remove_Tables_hreflinks(self):
-    '''This function Removes a table, if it contains an href link which means this is the table of contents!
-    As a side bonous, it also removes the phrase table of contents whithin the text (At the end of each page, there is sometimes links to the table of contents'''
+    '''This function removes a table if it contains an href link, which indicates it is the table of contents.
+    As a side bonus, it also removes the phrase "table of contents" within the text (at the end of each page there is sometimes a link to the table of contents).'''
 
     regex = '\s*table\s*of\s*contents'
     for element in self.soup.find_all('a', string=re.compile(regex, re.IGNORECASE)):
@@ -772,8 +772,8 @@ class Disclosure():
 
 
   def Remove_Tables_hreflinks(self):
-    '''This function Removes a table, if it contains an href link which means this is the table of contents!
-    As a side bonous, it also removes the phrase table of contents whithin the text (At the end of each page, there is sometimes links to the table of contents'''
+    '''This function removes a table if it contains an href link, which indicates it is the table of contents.
+    As a side bonus, it also removes the phrase "table of contents" within the text (at the end of each page there is sometimes a link to the table of contents).'''
 
     regex = '\s*table\s*of\s*contents'
     for element in self.soup.find_all('a', string=re.compile(regex, re.IGNORECASE)):


### PR DESCRIPTION
## Summary
- fix typo in `Remove_Tables_hreflinks` docstrings

## Testing
- `python -m py_compile src/Class_Function.py src/classes2.py`

------
https://chatgpt.com/codex/tasks/task_e_68406b6654d4832984f8f13993f009a2